### PR TITLE
fix(git): write config to ~/.config/git/config so VS Code can copy host ~/.gitconfig

### DIFF
--- a/git/setup.sh
+++ b/git/setup.sh
@@ -8,9 +8,11 @@ log() { printf "[git] %s\n" "$1"; }
 log "Copying .gitignore to ~/.gitignore"
 cp "${SCRIPT_DIR}/.gitignore" ~/.gitignore
 
-log "Configure git globally"
-git config --global core.excludesFile '~/.gitignore'
-git config --global pull.rebase true
-git config --global push.autoSetupRemote true
+log "Configure git via XDG (~/.config/git/config) so VS Code can still copy host ~/.gitconfig"
+mkdir -p ~/.config/git
+GIT_CFG=~/.config/git/config
+git config --file "${GIT_CFG}" core.excludesFile '~/.gitignore'
+git config --file "${GIT_CFG}" pull.rebase true
+git config --file "${GIT_CFG}" push.autoSetupRemote true
 
 log "Done."


### PR DESCRIPTION
Closes #15

## Summary

- Switch `git/setup.sh` from `git config --global` (which writes `~/.gitconfig`) to `git config --file ~/.config/git/config` (XDG path).
- VS Code Dev Containers only copies the host `~/.gitconfig` when the file does not yet exist in the container; creating it during dotfiles install caused VS Code to skip the copy, dropping the host `[user]` block.
- Git reads both files (per `git-config(1)`); `~/.gitconfig` still wins for single-valued keys, so host settings override our defaults — the desired behavior.

## Test plan

- [ ] Rebuild a VS Code Dev Container that runs this dotfiles install.
- [ ] Verify `~/.gitconfig` in the container contains the host `[user]` block (name/email).
- [ ] Verify `~/.config/git/config` contains `core.excludesFile`, `pull.rebase`, `push.autoSetupRemote`.
- [ ] Run `git config --get core.excludesFile` / `pull.rebase` / `push.autoSetupRemote` inside the container — values resolve correctly.
- [ ] Run `git config --get user.email` inside the container — returns host email.